### PR TITLE
Schema properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to the "vtexio-intellisense" extension will be documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased] - Release
+
+## Added
+
+- schema `properties` (alongside `patternProperties`)
+
 ## [0.1.2] - 2021-12-07
 
-## Fixed 
+## Fixed
 
 - validation path
 - no explict use blocks
@@ -14,7 +20,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - interfaces autocomplete
 
 ## [0.1.1] - 2021-12-06
-## Added 
+
+## Added
 
 - configuration `vtexiointellisense.allowsUnusedBlocks` to disable\enable warnings
 
@@ -33,7 +40,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### fixed
 
-- snippets scope 
+- snippets scope
 
 ## [0.0.2]
 

--- a/vtexio.schema.json
+++ b/vtexio.schema.json
@@ -2,6 +2,167 @@
 	"title": "VTEX IO Jsonc Schema by EPlus 💚",
 	"type": "object",
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"blog-latest-posts-preview.wordpress-latest-posts-preview": {
+			"$ref": "./schemas/wordpress-integration/blog-latest-posts-preview.wordpress-latest-posts-preview.schema.json"
+		},
+		"condition-layout.product": {
+			"$ref": "./schemas/condition-layout.product.schema.json"
+		},
+		"disclosure-content": {
+			"$ref": "./schemas/disclosure-layout/disclosure-content.schema.json"
+		},
+		"disclosure-layout-group": {
+			"$ref": "./schemas/disclosure-layout/disclosure-layout-group.schema.json"
+		},
+		"disclosure-layout": {
+			"$ref": "./schemas/disclosure-layout/disclosure-layout.schema.json"
+		},
+		"disclosure-state-indicator": {
+			"$ref": "./schemas/disclosure-layout/disclosure-state-indicator.schema.json"
+		},
+		"disclosure-trigger-group": {
+			"$ref": "./schemas/disclosure-layout/disclosure-trigger-group.schema.json"
+		},
+		"disclosure-trigger": {
+			"$ref": "./schemas/disclosure-layout/disclosure-trigger.schema.json"
+		},
+		"filter-navigator.v3": {
+			"$ref": "./schemas/search-result/filter-navigator.v3.schema.json"
+		},
+		"flex-layout.col": {
+			"$ref": "./schemas/flex-layout/flex-layout.col.schema.json"
+		},
+		"flex-layout.row": {
+			"$ref": "./schemas/flex-layout/flex-layout.row.schema.json"
+		},
+		"gallery-layout-option": {
+			"$ref": "./schemas/search-result/gallery-layout-option.schema.json"
+		},
+		"gallery-layout-switcher": {
+			"$ref": "./schemas/search-result/gallery-layout-switcher.schema.json"
+		},
+		"gallery": {
+			"$ref": "./schemas/search-result/gallery.schema.json"
+		},
+		"icon": {
+			"$ref": "./schemas/icon.schema.json"
+		},
+		"image": {
+			"$ref": "./schemas/image.schema.json"
+		},
+		"link": {
+			"$ref": "./schemas/link.schema.json"
+		},
+		"list-context.image-list": {
+			"$ref": "./schemas/list-context.image-list.schema.json"
+		},
+		"list-context.product-list": {
+			"$ref": "./schemas/list-context.product-list.schema.json"
+		},
+		"paged-controls": {
+			"$ref": "./schemas/search-result/paged-controls.schema.json"
+		},
+		"product-description": {
+			"$ref": "./schemas/store-components/product-description.schema.json"
+		},
+		"product-images": {
+			"$ref": "./schemas/store-components/product-images.schema.json"
+		},
+		"product-specification-badges": {
+			"$ref": "./schemas/product-specification-badges.schema.json"
+		},
+		"product-specification-group": {
+			"$ref": "./schemas/product-specifications/product-specification-group.schema.json"
+		},
+		"product-specification-text": {
+			"$ref": "./schemas/product-specifications/product-specification-text.schema.json"
+		},
+		"product-specification-value": {
+			"$ref": "./schemas/product-specifications/product-specification-value.schema.json"
+		},
+		"product-specification": {
+			"$ref": "./schemas/product-specifications/product-specification.schema.json"
+		},
+		"product-summary-image": {
+			"$ref": "./schemas/product-summary-image.schema.json"
+		},
+		"rich-text": {
+			"$ref": "./schemas/rich-text.schema.json"
+		},
+		"search-banner": {
+			"$ref": "./schemas/search/search-banner.schema.json"
+		},
+		"search-not-found-layout": {
+			"$ref": "./schemas/search-result/search-result-layout.schema.json"
+		},
+		"search-result-layout": {
+			"$ref": "./schemas/search-result/search-result-layout.schema.json"
+		},
+		"shelf.relatedProducts": {
+			"$ref": "./schemas/shelf.relatedProducts.schema.json"
+		},
+		"slider-layout": {
+			"$ref": "./schemas/slider-layout.schema.json"
+		},
+		"stack-layout": {
+			"$ref": "./schemas/stack-layout.schema.json"
+		},
+		"sticky-layout": {
+			"$ref": "./schemas/sticky-layout.schema.json"
+		},
+		"store.search": {
+			"$ref": "./schemas/search-result/store.search.schema.json"
+		},
+		"sku-selector": {
+			"$ref": "./schemas/store-components/sku-selector.schema.json"
+		},
+		"overlay-layout": {
+			"$ref": "./schemas/overlay-layout/overlay-layout.schema.json"
+		},
+		"overlay-trigger": {
+			"$ref": "./schemas/overlay-layout/overlay-trigger.schema.json"
+		},
+		"product-installments-list": {
+			"$ref": "./schemas/product-price/product-installments-list.schema.json"
+		},
+		"iframe": {
+			"$ref": "./schemas/iframe.schema.json"
+		},
+		"store.": {
+			"$ref": "./schemas/store.schema.json"
+		},
+		"newsletter-form": {
+			"$ref": "./schemas/newsletter/newsletter-form.schema.json"
+		},
+		"newsletter-input-name": {
+			"$ref": "./schemas/newsletter/newsletter-input-name.schema.json"
+		},
+		"newsletter-input-phone": {
+			"$ref": "./schemas/newsletter/newsletter-input-phone.schema.json"
+		},
+		"newsletter-input-email": {
+			"$ref": "./schemas/newsletter/newsletter-input-email.schema.json"
+		},
+		"newsletter-submit": {
+			"$ref": "./schemas/newsletter/newsletter-submit.schema.json"
+		},
+		"modal-actions.close": {
+			"$ref": "./schemas/modal/modal-actions.close.schema.json"
+		},
+		"modal-header": {
+			"$ref": "./schemas/modal/modal-header.schema.json"
+		},
+		"modal-layout": {
+			"$ref": "./schemas/modal/modal-layout.schema.json"
+		},
+		"modal-trigger": {
+			"$ref": "./schemas/modal/modal-trigger.schema.json"
+		},
+		"scroll-animate": {
+			"$ref": "./schemas/scroll-animate.schema.json"
+		}
+	},
 	"patternProperties": {
 		"^(blog-latest-posts-preview.wordpress-latest-posts-preview)": {
 			"$ref": "./schemas/wordpress-integration/blog-latest-posts-preview.wordpress-latest-posts-preview.schema.json"


### PR DESCRIPTION
O objetivo é oferecer autocomplete independente dos snippets. Usando `properties` além dos `patternProperties` fica possível de escolher qualquer bloco em uma lista, com `Ctrl + Espaço`

Exemplo:
![properties](https://i.imgur.com/Lk5CmFs.gif)
  