### PR TITLE
Update tab-list.item.schema.json

### DIFF
--- a/schemas/tab-layout/tab-list.item.schema.json
+++ b/schemas/tab-layout/tab-list.item.schema.json
@@ -20,6 +20,11 @@
 					"type": "string",
 					"markdownDescription": "`string`\n\nTab ID of your choosing. It will be used to match the tab to its content (defined by the `tab-content.item` block).",
 					"default": "Defines the tab's text label."
+				},
+				"defaultActiveTab": {
+					"type": "boolean",
+					"markdownDescription": "`boolean`\n\nDefines the item as the default active tab.",
+					"default": false
 				}
 			}
 		}


### PR DESCRIPTION
Add missing `defaultActiveTab` on tab-list.item. 
References: https://developers.vtex.com/vtex-developer-docs/docs/vtex-tab-layout#tab-listitem-props